### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/18-36415-1/0632297e-d827-403e-b8cb-e7377374930e/9f537680-d0fc-4eeb-b723-6c68bd4907d1/_apis/work/boardbadge/61306f07-61a9-4b78-92a6-5ba4ae915fcf)](https://dev.azure.com/18-36415-1/0632297e-d827-403e-b8cb-e7377374930e/_boards/board/t/9f537680-d0fc-4eeb-b723-6c68bd4907d1/Microsoft.RequirementCategory)
 # GuessTheNumber_V1
 
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/18-36415-1/0632297e-d827-403e-b8cb-e7377374930e/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.